### PR TITLE
Fix Iterable import for python 3.10

### DIFF
--- a/cachesim/cache.py
+++ b/cachesim/cache.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import textwrap
 from functools import reduce
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 from cachesim import backend
 


### PR DESCRIPTION
The title says everthing, in python 3.10 you have to import the abstract collection classes from a submodule.