### PR TITLE
Fix timer for 3.3+ and make tests work

### DIFF
--- a/tests/perf_tests.py
+++ b/tests/perf_tests.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import
 import time
 import sys
 import cProfile
-sys.path[0:0] = ['.', '..']
+#sys.path[0:0] = ['.', '..']
 
-from cachesim import CacheSimulator, Cache
+from cachesim import CacheSimulator, Cache, MainMemory
 
 
 def do_cprofile(func):
@@ -25,51 +25,60 @@ def do_cprofile(func):
 
 
 class Timer:
+    mytime = None
+    if sys.version_info >= (3,3):
+        mytime = time.monotonic
+    else:
+        mytime = time.clock
     def __enter__(self):
-        self.start = time.clock()
+        self.start = self.mytime()
         return self
 
     def __exit__(self, *args):
-        self.end = time.clock()
+        self.end = self.mytime()
         self.interval = self.end - self.start
 
 
 class TimingTests:
     def time_load1000_tiny(self):
-        l3 = Cache(4, 8, 8, "LRU")
-        l2 = Cache(4, 4, 8, "LRU", parent=l3)
-        l1 = Cache(2, 4, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4, 8, 8, "LRU")
+        l2 = Cache("L2", 4, 4, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 2, 4, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         
         with Timer() as t:
             mh.load(0, 1000)
         return t.interval
     
     def time_load10000_tiny(self):
-        l3 = Cache(4, 8, 8, "LRU")
-        l2 = Cache(4, 4, 8, "LRU", parent=l3)
-        l1 = Cache(2, 4, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4, 8, 8, "LRU")
+        l2 = Cache("L2", 4, 4, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 2, 4, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         
         with Timer() as t:
             mh.load(0, 10000)
         return t.interval
     
     def time_load100000_tiny(self):
-        l3 = Cache(4, 8, 8, "LRU")
-        l2 = Cache(4, 4, 8, "LRU", parent=l3)
-        l1 = Cache(2, 4, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4, 8, 8, "LRU")
+        l2 = Cache("L2", 4, 4, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 2, 4, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         
         with Timer() as t:
             mh.load(0, 100000)
         return t.interval
     
     def time_load100000_tiny_collisions(self):
-        l3 = Cache(4, 8, 8, "LRU")
-        l2 = Cache(4, 4, 8, "LRU", parent=l3)
-        l1 = Cache(2, 4, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4, 8, 8, "LRU")
+        l2 = Cache("L2", 4, 4, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 2, 4, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         mh.load(0, 100000)
         
         with Timer() as t:
@@ -78,20 +87,22 @@ class TimingTests:
 
     @do_cprofile
     def time_load1000000(self):
-        l3 = Cache(4096, 1024, 8, "LRU")
-        l2 = Cache(4096, 8, 8, "LRU", parent=l3)
-        l1 = Cache(512, 8, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4096, 1024, 8, "LRU")
+        l2 = Cache("L2", 4096, 8, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 512, 8, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         
         with Timer() as t:
             mh.load(0, 1000000)
         return t.interval
 
     def time_load1000000_collisions(self):
-        l3 = Cache(4096, 1024, 8, "LRU")
-        l2 = Cache(4096, 8, 8, "LRU", parent=l3)
-        l1 = Cache(512, 8, 8, "LRU", parent=l2)
-        mh = CacheSimulator(l1)
+        l3 = Cache("L3", 4096, 1024, 8, "LRU")
+        l2 = Cache("L2", 4096, 8, 8, "LRU", store_to=l3, load_from=l3)
+        l1 = Cache("L1", 512, 8, 8, "LRU", store_to=l2, load_from=l2)
+        mem = MainMemory("MEM", l3, l3)
+        mh = CacheSimulator(l1, mem)
         mh.load(0, 1000000)
         
         with Timer() as t:


### PR DESCRIPTION
- Use `time.monotonic()` for Python 3.3+
- Use installed `cachesim` module or testing
- Fix all testcases:
  - Replace `parent` with `load_from` and `store_to`
  - Added MainMemory attached to L3